### PR TITLE
Topico 6 - Aula 4 - Elementos Dinamicos

### DIFF
--- a/resources/keywords/Widgets/widgets.keywords.resource
+++ b/resources/keywords/Widgets/widgets.keywords.resource
@@ -78,3 +78,25 @@ Move A List Items To Drop Zone
         Move Item Of Sort Zone To Drop Zone    ${item}
     END
     Validate Dropped Items Order    @{items}
+
+Hide Dinamic Element
+    Click On Visibility Controll Button    Ocultar
+    Check Dinâmic Element    Este elemento pode ser ocultado/mostrado dinamicamente    hidden
+    Take Screenshot
+
+Show Dinamic Element
+    Click On Visibility Controll Button    Mostrar
+    Check Dinâmic Element    Este elemento pode ser ocultado/mostrado dinamicamente    visible
+    Take Screenshot
+
+Expand Dynamic Element
+    Click On Expanded Controll Button    Expandir
+    Check Expanded Content    Conteúdo expandido que só aparece quando necessário.
+    Check Expanded Content    Este tipo de elemento é comum em accordions e seções colapsíveis.
+    Take Screenshot
+
+Retract Dynamic Element
+    Click On Expanded Controll Button    Recolher
+    Check Expanded Content    Conteúdo expandido que só aparece quando necessário.    0
+    Check Expanded Content    Este tipo de elemento é comum em accordions e seções colapsíveis.    0
+    Take Screenshot

--- a/resources/keywords/Widgets/widgets.page.resource
+++ b/resources/keywords/Widgets/widgets.page.resource
@@ -175,3 +175,20 @@ Validate Dropped Items Order
     FOR    ${index}    ${element}    IN ENUMERATE    @{expected_order}
         Wait For Elements State    ${elements}[${index}] >> text=Item ${element}    visible
     END
+
+Click On Visibility Controll Button
+    [Arguments]    ${expected_text}
+    Click    ${BTN_EDIT_TOGGLE_VISIBILITY} >> text=${expected_text}
+
+Check Dinâmic Element
+    [Arguments]    ${expectd_text}    ${state}=visible
+    Wait For Elements State    ${DYNAMIC_ELEMENT} >> text=${expectd_text}    ${state}
+
+Click On Expanded Controll Button
+    [Arguments]    ${expected_text}
+    Click    ${BTN_TOGGLE_EXPAND} >> text=${expected_text}
+
+Check Expanded Content
+    [Arguments]    ${expected_content}    ${opacity}=100
+    ${element}=    Replace String    ${EXPANDABLE_CONTENT}    $$    ${opacity}
+    Wait For Elements State    ${element} >> text=${expected_content}    visible

--- a/resources/keywords/Widgets/widgets.variables.resource
+++ b/resources/keywords/Widgets/widgets.variables.resource
@@ -33,3 +33,9 @@ ${DROPPED_ITEM}=                    data-testid=stats-value-dropped-item-
 
 ${DROPPED_DRAGGABLE_ITEM}=          ${DROP_ZONE} >> div[draggable="true"]
 ${SORTED_DRAGGABLE_ITEM}=           ${SORTABLE_ZONE} >> div[draggable="true"]
+
+${BTN_EDIT_TOGGLE_VISIBILITY}=      data-testid=btn-edit-toggle-visibility
+${DYNAMIC_ELEMENT}=                 data-testid=stats-value-dynamic-element
+
+${BTN_TOGGLE_EXPAND}=               data-testid=btn-edit-toggle-expand
+${EXPANDABLE_CONTENT}=              div[data-testid="stats-value-expandable-content"].opacity-$$ p

--- a/tests/mobile/widgets.robot
+++ b/tests/mobile/widgets.robot
@@ -70,3 +70,13 @@ It Must Be Possible Re-Arrange Items In Sortable Zone
 It Must Be Possible Re-Arrange Items In Dropped Zone
     [Tags]    drag_drop
     Move A List Items To Drop Zone    1    3    4    2
+
+Should Be Possible Show And Hide Dinamic element
+    [Tags]    visibility
+    Hide Dinamic Element
+    Show Dinamic Element
+
+Should Be Possible Expand And Retract Dynamic Element
+    [Tags]    expand_retract
+    Expand Dynamic Element
+    Retract Dynamic Element

--- a/tests/web/widgets.robot
+++ b/tests/web/widgets.robot
@@ -70,3 +70,13 @@ It Must Be Possible Re-Arrange Items In Sortable Zone
 It Must Be Possible Re-Arrange Items In Dropped Zone
     [Tags]    drag_drop
     Move A List Items To Drop Zone    1    3    4    2
+
+Should Be Possible Show And Hide Dinamic element
+    [Tags]    visibility
+    Hide Dinamic Element
+    Show Dinamic Element
+
+Should Be Possible Expand And Retract Dynamic Element
+    [Tags]    expand_retract
+    Expand Dynamic Element
+    Retract Dynamic Element


### PR DESCRIPTION
Elementos que mudam de estado dinamicamente

## **Controle de Visibilidade**

Existem recursos onde controlamos a visibilidade dos itens. Um exemplo são botões onde podemos ocultar elementos na tela.

Vamos começar mapeando o botão de controle de visibilidade e o elemento dinâmico

**resources/keywords/Widgets/widgets.variables.resource**

```
${BTN_EDIT_TOGGLE_VISIBILITY}=      data-testid=btn-edit-toggle-visibility
${DYNAMIC_ELEMENT}=                 data-testid=stats-value-dynamic-element
```

Agora podemos realizar as interações

**resources/keywords/Widgets/widgets.page.resource**

```
Click On Visibility Controll Button
    [Arguments]    ${expected_text}
    Click    ${BTN_EDIT_TOGGLE_VISIBILITY} >> text=${expected_text}

Check Dinâmic Element
    [Arguments]    ${expectd_text}
    Wait For Elements State    ${DYNAMIC_ELEMENT} >> text=${expectd_text}    visible

```

Agora podemos contruir um fluxo para estas ações

**resources/keywords/Widgets/widgets.keywords.resource**

```
Hide Dinamic Element
    Click On Visibility Controll Button    Ocultar
    Check Dinâmic Element    Este elemento pode ser ocultado/mostrado dinamicamente    hidden

Show Dinamic Element
    Click On Visibility Controll Button    Mostrar
    Check Dinâmic Element    Este elemento pode ser ocultado/mostrado dinamicamente    visible

```

Por fim nosso teste fica da seguinte forma:

**tests/web/widgets.robot**

```
Should Be Possible Show And Hide Dinamic element
    [Tags]    visibility
    Hide Dinamic Element
    Show Dinamic Element
```

---

## **Seção Expansível**

Mapear elementos

**resources/keywords/Widgets/widgets.variables.resource**

```
${BTN_TOGGLE_EXPAND}=               data-testid=btn-edit-toggle-expand
${EXPANDABLE_CONTENT}=              data-testid=stats-value-expandable-content
```

Criar as interações com elementos

**resources/keywords/Widgets/widgets.page.resource**

```
Click On Expanded Controll Button
    [Arguments]    ${expected_text}
    Click    ${BTN_TOGGLE_EXPAND} >> text=${expected_text}

Check Expanded Content
    [Arguments]    ${expected_content}    ${state}=visible
    Wait For Elements State    ${EXPANDABLE_CONTENT} >> p >> text=${expected_content}    ${state}
```

Criar fluxos para validar o comportamento

**resources/keywords/Widgets/widgets.keywords.resource**

```
Expand Dynamic Element
    Click On Expanded Controll Button    Expandir
    Check Expanded Content    Conteúdo expandido que só aparece quando necessário.
    Check Expanded Content    Este tipo de elemento é comum em accordions e seções colapsíveis.
    Take Screenshot

Retract Dynamic Element
    Click On Expanded Controll Button    Recolher
    Check Expanded Content    Conteúdo expandido que só aparece quando necessário.    hidden
    Check Expanded Content    Este tipo de elemento é comum em accordions e seções colapsíveis.    hidden
    Take Screenshot

```

Ao final nosso teste ficaria da seguinte forma

**tests/web/widgets.robot**

```
Should Be Possible Expand And Retract Dynamic Element
    [Tags]    expand_retract
    Expand Dynamic Element
    Retract Dynamic Element
```

Quando executamos ele vemos que temos uma falha pois o elemento ainda esta visível. Precisamos na real validar o opacity dele. Dado isso precisamos de uma nova extratégia para validar o item.

Novo locator

**resources/keywords/Widgets/widgets.variables.resource**

```yaml
${EXPANDABLE_CONTENT}=              div[data-testid="stats-value-expandable-content"].opacity-$$ p
```

Com isso mudamos também a implementação para validar o item

**resources/keywords/Widgets/widgets.page.resource**

```
Check Expanded Content
    [Arguments]    ${expected_content}    ${opacity}=100
    ${element}=    Replace String    ${EXPANDABLE_CONTENT}    $$    ${opacity}
    Wait For Elements State    ${element} >> text=${expected_content}    visible
```

A keyword que retrai o item agore precisa receber o valor 0 para opacity

**resources/keywords/Widgets/widgets.keywords.resource**

```
Retract Dynamic Element
    Click On Expanded Controll Button    Recolher
    Check Expanded Content    Conteúdo expandido que só aparece quando necessário.    0
    Check Expanded Content    Este tipo de elemento é comum em accordions e seções colapsíveis.    0
    Take Screenshot
```

---

Contador já foi automatizado em outro módulo